### PR TITLE
Create release per git tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Test build and package QubesOS RPMs
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    tags:
+      - '*'
 
 jobs:
   qubes-dom0-package:


### PR DESCRIPTION
Requires https://github.com/TrenchBoot/.github/pull/2.

For a test see [this CI build](https://github.com/TrenchBoot/qubes-antievilmaid/actions/runs/6398819141) and [test release created by it](https://github.com/TrenchBoot/qubes-antievilmaid/releases/tag/very-real-release).