### PR TITLE
sbin/tpm2-evt-log-parser.awk: Fix reference to uninitialized element

### DIFF
--- a/sbin/tpm2-evt-log-parser.awk
+++ b/sbin/tpm2-evt-log-parser.awk
@@ -8,8 +8,10 @@ BEGIN {
 	ord_init()
 	SHA1_17 = ""
 	SHA1_18 = ""
+	SHA1_255 = ""
 	SHA256_17 = ""
 	SHA256_18 = ""
+	SHA256_255 = ""
 }
 {
 	# Header sanity checks

--- a/sbin/txt-tpm1-evt-log-parser.awk
+++ b/sbin/txt-tpm1-evt-log-parser.awk
@@ -9,6 +9,7 @@ BEGIN {
 	ord_init()
 	SHA1_17 = ""
 	SHA1_18 = ""
+	SHA1_255 = ""
 }
 {
 	# TCG header is not present on Intel systems, so do nothing if it's not


### PR DESCRIPTION
Fixes the issue with reference to uninitialized element :

```
Entry 2:
    PCR:        255
    Event Type: 0x401
    Digests:
      SHA256: 0000000000000000000000000000000000000000000000000000000000000000
gawk: /usr/sbin/tpm2-evt-log-parser.awk:67: (FILENAME=/tmp/log.bin FNR=1) fatal: reference to uninitialized element `SYMTAB["SHA256_255"] is not allowed'
```

The PCR mapping event uses the PCR 0xff according to Intel TXT MLE Software Development Guide.